### PR TITLE
skill/create-skill: rewrite for low context weight + path fix

### DIFF
--- a/create-skill/SKILL.md
+++ b/create-skill/SKILL.md
@@ -49,4 +49,4 @@ Imperative content...
 **Global:** `~/Agents/skills/<name>/SKILL.md`  
 **Project-local:** `skills/<name>/SKILL.md` (from project root)
 
-Commit skills to git.
+Branch with `git`, PR with `gh`, pull with `git`.


### PR DESCRIPTION
## Summary
- Replace 6-step procedural walkthrough with dense reference sections
- Use imperatives, strip prose and meta-commentary
- Halve line count: 80 → 52 lines
- Preserve all structural guidance and format specs
- Update paths to `~/Agents/skills/` (new canonical location)

## Changes

**Before (80 lines):**
- Step 1/2/3... numbered list with prose explanations
- Meta-commentary ("tips", "best practices")
- Verbose description field

**After (52 lines):**
- Direct imperative sections
- Compact formatting
- No prose padding

## Review checklist
- [ ] All original rules/guidance preserved?
- [ ] Trigger conditions still clear?
- [ ] Format spec still accurate?
- [ ] Paths updated correctly?