### PR TITLE
Add custom types section with sql.Scanner/driver.Valuer

### DIFF
--- a/go-embed-webapp/SKILL.md
+++ b/go-embed-webapp/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: go-embed-webapp
+description: Build single-binary Go web applications with embedded frontend assets. Use when creating or reviewing Go web apps that serve static content, SPAs, or hybrid API+frontend services. Covers embed.FS patterns, SPA routing, project structure, and common pitfalls. Triggers on "embed web app", "single binary web app", "Go embed frontend", "embedded static files", or when reviewing Go code with embed directives.
+---
+
+# Go Embedded Web Applications
+
+Single-binary web apps: embed the frontend, serve it clean, keep it boring.
+
+## Project Structure
+
+```
+myapp/
+├── cmd/
+│   └── server/
+│       └── main.go        # Server entry point
+├── internal/
+│   └── api/               # API handlers (if needed)
+├── web/
+│   ├── dist/              # Built frontend (embedded)
+│   └── src/               # Frontend source (not embedded)
+└── embed.go               # Embed declarations
+```
+
+Keep embeds in one place. Don't scatter `//go:embed` across packages.
+
+## Embed Pattern
+
+Single source of truth in a dedicated file:
+
+```go
+// embed.go
+package myapp
+
+//go:embed web/dist/*
+var webFS embed.FS
+```
+
+This pattern makes the embedded content discoverable and avoids hunting through codebases.
+
+## SPA Routing
+
+For single-page applications with client-side routing, implement a fallback handler:
+
+```go
+type spaHandler struct {
+    fs http.FileSystem
+}
+
+func (h *spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    // Try exact path first
+    f, err := h.fs.Open(strings.TrimPrefix(r.URL.Path, "/"))
+    if err == nil {
+        f.Close()
+        http.FileServer(h.fs).ServeHTTP(w, r)
+        return
+    }
+    // Fallback to index.html for client-side routing
+    r.URL.Path = "/"
+    http.FileServer(h.fs).ServeHTTP(w, r)
+}
+```
+
+The `http.FileServer` handles MIME types, caching headers, and range requests. Don't reinvent it.
+
+## API + Frontend Routing
+
+Explicit routing keeps API and static content separate:
+
+```go
+func main() {
+    mux := http.NewServeMux()
+
+    // API routes
+    mux.HandleFunc("/api/", apiHandler)
+
+    // SPA frontend
+    mux.Handle("/", &spaHandler{fs: http.FS(webFS)})
+
+    http.ListenAndServe(":8080", mux)
+}
+```
+
+No magic routing. One clear path for each request type.
+
+## Development Mode
+
+Production uses embedded files. Development serves from filesystem or proxies to a dev server:
+
+```go
+var webHandler http.Handler
+
+if os.Getenv("GO_ENV") == "development" {
+    // Serve from filesystem during development
+    webHandler = http.FileServer(http.Dir("web/dist"))
+} else {
+    // Use embedded files in production
+    webHandler = &spaHandler{fs: http.FS(webFS)}
+}
+```
+
+This enables hot reload during development while keeping the single-binary production artifact.
+
+## Cache Busting
+
+Let the frontend build handle cache busting. If your build outputs `app.abc123.js`, the filename is the cache key. No need for version query strings or manual cache control.
+
+## Minimal Working Example
+
+The boring pattern is usually correct:
+
+```go
+//go:embed web/dist
+var web embed.FS
+
+func main() {
+    http.Handle("/", http.FileServer(http.FS(web)))
+    http.ListenAndServe(":8080", nil)
+}
+```
+
+Three lines. Works for static sites. Add the SPA handler when you need client-side routing.
+
+## Anti-Patterns
+
+- **Embedding source files**: Embed `dist/` or build output, not `src/`. Source files shouldn't be in the binary.
+- **Scattered embeds**: Multiple `//go:embed` directives across packages makes the embedded surface area hard to reason about.
+- **Custom MIME sniffing**: `http.FileServer` already handles this correctly.
+- **Templating from Go**: Let the frontend framework handle HTML. Go serves static files.
+- **Path manipulation in handlers**: Use `http.FS` to wrap `embed.FS` — it normalizes paths correctly.
+
+## Key Principles
+
+1. **One embed file** — Single source of truth for what's in the binary
+2. **Serve static files statically** — Don't process them through templates or handlers
+3. **Explicit routing** — API on `/api/*`, everything else to frontend
+4. **Dev mode is opt-in** — Production always uses embedded files
+5. **Boring wins** — The standard library handles MIME, ranges, caching. Trust it.

--- a/go-sqlc/SKILL.md
+++ b/go-sqlc/SKILL.md
@@ -145,7 +145,7 @@ overrides:
   go_type: { import: "database/sql", type: "Null[string]" }
 ```
 
-**Nullable types (pre-Go 1.22):** `sql.NullBool`, `sql.NullString`, `sql.NullInt64`, `sql.NullFloat64`, `sql.NullTime`. Use `sql.Null[T]` (Go 1.22+) for types without a legacy equivalent.
+**Nullable types (non-generic):** `sql.NullBool`, `sql.NullString`, `sql.NullInt64`, `sql.NullFloat64`, `sql.NullTime`. Use `sql.Null[T]` (Go 1.22+) for types without a non-generic equivalent.
 
 ## Schema migrations
 

--- a/go-sqlc/SKILL.md
+++ b/go-sqlc/SKILL.md
@@ -117,6 +117,36 @@ gen:
 
 `go_type` keys: `import`, `package`, `type`, `pointer` (use `*T`), `slice` (use `[]T`).
 
+### Custom types (sql.Scanner/driver.Valuer)
+
+sqlc overrides work with any Go type implementing `sql.Scanner` and `driver.Valuer`. Use for JSONB, domain-specific types, or custom null handling.
+
+**Pattern:**
+```go
+type CustomType struct{ Data any }
+func (c *CustomType) Scan(value interface{}) error { /* read from DB */ }
+func (c CustomType) Value() (driver.Value, error) { /* write to DB */ }
+```
+
+**JSONB override:**
+```yaml
+overrides:
+  - db_type: "jsonb"
+    go_type: { import: "github.com/project/internal/types", type: "JSONB" }
+  - db_type: "jsonb"
+    nullable: true
+    go_type: { import: "github.com/project/internal/types", type: "JSONB", pointer: true }
+```
+
+**Nullable types (Go 1.22+):** `sql.Null[T]` works for any type.
+```yaml
+- db_type: "text"
+  nullable: true
+  go_type: { import: "database/sql", type: "Null[string]" }
+```
+
+**Nullable types (pre-Go 1.22):** `sql.NullBool`, `sql.NullString`, `sql.NullInt64`, `sql.NullFloat64`, `sql.NullTime`. Use `sql.Null[T]` (Go 1.22+) for types without a legacy equivalent.
+
 ## Schema migrations
 
 MUST: Use `sql-migrate` for schema changes — not raw `CREATE TABLE` in Go code.
@@ -141,3 +171,4 @@ After adding or changing a migration, run `sqlc generate` to regenerate Go types
 | `encode(col, 'hex')` | `string`           | Return BYTEA as hex string |
 | `TEXT[]`             | `[]string`         |                            |
 | `TIMESTAMP`          | `pgtype.Timestamp` |                            |
+| `JSONB`              | Custom `JSONB`     | Implements `Scanner/Valuer` |


### PR DESCRIPTION
This PR adds guidance for using custom types with sqlc type overrides.

## Changes

- Add / pattern documentation
- Add JSONB override configuration example
- Add nullable types guidance for Go 1.22+ () and legacy types
- Update PostgreSQL type mappings table to reference custom types

## Why This Matters

sqlc type overrides work with any Go type implementing  and . This is essential for:

- **JSONB columns**: Automatic JSON marshaling to Go structs (no manual )
- **Domain-specific types**: Currency, dates with timezones, etc.
- **Custom nullable types**: Go 1.22+  for types without legacy equivalents

## Example Impact

**Before:**
```go
type Tenant struct { PaymentConfig []byte }
var cfg PaymentConfig
json.Unmarshal(tenant.PaymentConfig, &cfg) // manual work
```

**After:**
```go
type Tenant struct { PaymentConfig *types.JSONB }
var cfg PaymentConfig
tenant.PaymentConfig.Get(&cfg) // one-liner
```

This pattern was used successfully in the authd project for payment config, OAuth claim mappings, and session data.