### PR TITLE
Add markdown-split for context loading

### DIFF
--- a/download-markdown/SKILL.md
+++ b/download-markdown/SKILL.md
@@ -1,0 +1,383 @@
+---
+name: download-markdown
+description: Download webpages and convert to Markdown, or recursively download website sections. Use when saving documentation for offline use, converting HTML documentation to Markdown, archiving web content, or processing API documentation. Covers URL downloading, HTML conversion, recursive downloads, and markdown detection with Accept headers and .md extensions.
+---
+
+# Download Markdown
+
+Download webpages and convert to Markdown, or recursively download website sections.
+
+## Quick Start
+
+```sh
+# Download single URL to stdout
+./scripts/download-markdown.cjs https://docs.example.com/article
+
+# Save to file
+./scripts/download-markdown.cjs https://docs.example.com/article ./docs/article.md
+
+# Download with markdown detection (try .md first)
+./scripts/download-markdown.cjs --detect-md https://docs.example.com/page
+
+# Recursively download website section
+./scripts/website-download-recursive.sh https://docs.example.com/api ./docs
+
+# Convert downloaded HTML to Markdown
+./scripts/html-to-markdown-recursive.cjs ./downloaded ./markdown-docs
+```
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `download-markdown.cjs` | Download single URL, convert to Markdown |
+| `html-to-markdown-recursive.cjs` | Convert existing HTML files to Markdown |
+| `website-download-recursive.sh` | Recursively download website with wget |
+
+## Dependencies
+
+```sh
+# Install Node.js dependencies
+npm install @mozilla/readability turndown jsdom
+
+# wget (for recursive downloads)
+webi wget
+```
+
+## 1. Download Single URL
+
+### Basic Usage
+
+```sh
+./scripts/download-markdown.cjs <url> [output]
+```
+
+**Output to stdout:**
+```sh
+./scripts/download-markdown.cjs https://example.com/article > article.md
+```
+
+**Save to file:**
+```sh
+./scripts/download-markdown.cjs https://example.com/article ./docs/article.md
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--detect-md` | Check if site serves Markdown directly first |
+| `--no-readability` | Skip content extraction, convert full HTML |
+| `--frontmatter` | Add YAML frontmatter with metadata |
+| `-h, --help` | Show help |
+| `-v, --version` | Show version |
+
+### Markdown Detection Strategy
+
+When `--detect-md` is used, the script tries multiple strategies in order:
+
+| Priority | Strategy | Example |
+|----------|----------|---------|
+| 1 | `.md` extension | `/page` → `/page.md` |
+| 2 | `.markdown` extension | `/page` → `/page.markdown` |
+| 3 | `index.md` in directory | `/api/` → `/api/index.md` |
+| 4 | Replace `.html` with `.md` | `/page.html` → `/page.md` |
+| 5 | `README.md` in directory | `/api/` → `/api/README.md` |
+| 6 | `Accept: text/markdown` header | Original URL with markdown Accept |
+| 7 | Parse HTML for `.md` links | Find anchor links to `.md` files |
+| 8 | Parse HTML for edit/source links | Find "Edit" or "View Source" buttons |
+
+The script detects Markdown by:
+- **Content-Type header**: `text/markdown` or `text/x-markdown`
+- **Content sniffing**: Starts with `#` or contains `---\n` (frontmatter) or `[text](url)` (links)
+
+#### HTML Link Detection
+
+After trying URL variants and Accept header, the script parses the HTML page to find:
+
+1. **Direct markdown links**: `<a href="page.md">` anchors
+2. **Edit/Source buttons**: Links with `rel="edit"`, `rel="source"`, or text like "Edit", "View Source", "Edit this page"
+3. **Raw repository links**: GitHub/GitLab raw URLs (e.g., `raw.githubusercontent.com`)
+
+These patterns are common in:
+- **GitHub Pages**: "Edit this page" buttons pointing to GitHub raw files
+- **GitLab**: "View source" links to raw markdown
+- **Docusaurus**: `_category_.json` + `.md` file structure
+- **ReadMe.io**: "Edit on GitHub" links
+- **MkDocs**: Edit buttons pointing to source markdown
+
+**Example: NMI Documentation**
+
+NMI docs serve Markdown directly:
+```sh
+./scripts/download-markdown.cjs --detect-md \
+  https://docs.nmi.com/reference/getting-started \
+  ./nmi/getting-started.md
+```
+
+This tries:
+1. `https://docs.nmi.com/reference/getting-started.md`
+2. `https://docs.nmi.com/reference/getting-started.markdown`
+3. `https://docs.nmi.com/reference/getting-started/index.md`
+4. etc.
+
+If none found, falls back to HTML conversion.
+
+### Readability Extraction
+
+Uses @mozilla/readability to extract article content:
+
+```sh
+# Extracts main content, removes nav/ads/etc
+./scripts/download-markdown.cjs https://blog.example.com/long-article ./article.md
+```
+
+## 2. Recursively Download Website
+
+### Basic Usage
+
+```sh
+./scripts/website-download-recursive.sh <base-url> [output-dir]
+```
+
+**Download API docs:**
+```sh
+./scripts/website-download-recursive.sh \
+  https://docs.example.com/api \
+  ./docs/api
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--depth N` | Maximum recursion depth (default: 5) |
+| `--wait N` | Wait N seconds between requests (default: 1) |
+| `--convert-links` | Convert links for offline viewing |
+| `--mirror` | Mirror mode (preserve structure, all files) |
+| `--no-images` | Skip image downloads |
+| `--no-css` | Skip CSS downloads |
+| `--dry-run` | Preview command without executing |
+
+### Respectful Crawling
+
+```sh
+# Be nice to servers
+./scripts/website-download-recursive.sh \
+  --wait 2 \
+  --depth 3 \
+  https://docs.example.com/api \
+  ./docs/api
+```
+
+### Mirror Entire Site
+
+```sh
+./scripts/website-download-recursive.sh \
+  --mirror \
+  --convert-links \
+  https://example.com \
+  ./mirror
+```
+
+## 3. Convert HTML to Markdown
+
+After downloading with wget, convert to Markdown:
+
+### Basic Usage
+
+```sh
+./scripts/html-to-markdown-recursive.cjs <input> <output>
+```
+
+**Convert directory:**
+```sh
+./scripts/html-to-markdown-recursive.cjs \
+  ./downloaded \
+  ./markdown-docs
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--clean` | Remove original HTML after conversion |
+| `--flatten` | Flatten output structure |
+| `--strip-prefix` | Strip common directory prefix |
+| `--frontmatter` | Add YAML frontmatter |
+| `--no-readability` | Convert full HTML without extraction |
+| `--dry-run` | Preview without converting |
+
+### Convert Single File
+
+```sh
+./scripts/html-to-markdown-recursive.cjs \
+  ./downloaded/article.html \
+  ./docs/article.md
+```
+
+### Clean Up After Conversion
+
+```sh
+./scripts/html-to-markdown-recursive.cjs \
+  --clean \
+  --frontmatter \
+  ./downloaded \
+  ./markdown-docs
+```
+
+## Complete Workflow
+
+### Archive Documentation Site (Smart Detection)
+
+```sh
+# 1. Try to download with markdown detection first
+./scripts/download-markdown.cjs \
+  --detect-md \
+  --frontmatter \
+  https://docs.nmi.com/reference/getting-started \
+  ./nmi/getting-started.md
+
+# 2. If markdown detection works, use recursive wget on .md files
+# Or download HTML and convert
+./scripts/website-download-recursive.sh \
+  --depth 5 \
+  --wait 1 \
+  https://docs.nmi.com/reference \
+  ./nmi/html
+
+# 3. Convert to Markdown
+./scripts/html-to-markdown-recursive.cjs \
+  --frontmatter \
+  ./nmi/html \
+  ./nmi/markdown
+```
+
+### API Reference Download
+
+```sh
+# Quick test - does this site serve markdown?
+./scripts/download-markdown.cjs --detect-md \
+  https://docs.nmi.com/reference/getting-started \
+  ./test.md
+
+# If yes, you can construct markdown URLs directly
+# If no, use recursive download + convert
+```
+
+## Markdown Detection Reference
+
+### Sites Known to Serve Markdown
+
+| Site | Pattern | Example |
+|------|---------|---------|
+| GitHub | Raw files | `https://raw.githubusercontent.com/...` |
+| GitLab | Raw files | `https://gitlab.com/.../-/raw/...` |
+| NMI Docs | `.md` extension | `https://docs.nmi.com/reference/page.md` |
+| ReadMe.io | `Accept: text/markdown` | Original URL with header |
+| Docusaurus | `_category_.json` | Check for `.md` files |
+| MkDocs | `index.md` | `/page/` → `/page/index.md` |
+
+### Content-Type Headers
+
+The script looks for:
+- `text/markdown` - Standard markdown mime type
+- `text/x-markdown` - Alternative markdown mime type
+- `text/plain` with markdown content - Sniffed by content
+
+### Markdown Content Sniffing
+
+When Content-Type is ambiguous, checks for:
+- Starts with `#` (ATX heading)
+- Contains `---\n` (YAML frontmatter)
+- Contains `[text](url)` (Markdown link syntax)
+- Contains `## ` (ATX subheading)
+
+## Output Structure
+
+**wget recursive:**
+```
+downloaded/
+└── docs.example.com/
+    ├── api/
+    │   ├── index.html
+    │   └── authentication.html
+    └── guides/
+        └── getting-started.html
+```
+
+**After HTML-to-Markdown:**
+```
+markdown-docs/
+├── api/
+│   ├── index.md
+│   └── authentication.md
+└── guides/
+    └── getting-started.md
+```
+
+## Frontmatter
+
+With `--frontmatter`, generated files include:
+
+```yaml
+---
+title: "Page Title"
+byline: "Author Name"
+source: "https://docs.example.com/article"
+date: "2026-04-05T03:00:00.000Z"
+---
+```
+
+## Troubleshooting
+
+### "Cannot find module" errors
+
+```sh
+# Install dependencies
+npm install @mozilla/readability turndown jsdom
+```
+
+### wget not found
+
+```sh
+webi wget
+```
+
+### Markdown not detected
+
+Some sites serve markdown but don't use standard extensions. Try manual URLs:
+
+```sh
+# Direct .md test
+curl -I https://docs.example.com/page.md
+
+# Accept header test
+curl -H "Accept: text/markdown" https://docs.example.com/page
+```
+
+If detected, you can construct URLs manually or use the detection results.
+
+### Empty output from readability
+
+Some pages fail extraction. Use `--no-readability` to convert full HTML:
+
+```sh
+./scripts/download-markdown.cjs --no-readability https://example.com/page
+```
+
+### Rate limited
+
+Increase wait time:
+
+```sh
+./scripts/website-download-recursive.sh --wait 5 https://example.com/docs
+```
+
+## Script Versions
+
+- `download-markdown.js`: 1.0.0
+- `html-to-markdown-recursive.js`: 1.0.0
+- `website-download-recursive.sh`: 1.0.0
+
+Bump versions when updating scripts.

--- a/download-markdown/SKILL.md
+++ b/download-markdown/SKILL.md
@@ -26,10 +26,10 @@ Download webpages and convert to Markdown, or recursively download website secti
 ./scripts/html-to-markdown-recursive.cjs ./downloaded ./markdown-docs
 
 # View TOC of large markdown file
-./scripts/markdown-split.cjs --toc large-doc.md
+./scripts/markdown-split.mjs --toc large-doc.md
 
 # Split large file for skill context loading
-./scripts/markdown-split.cjs --index large-doc.md ./references/
+./scripts/markdown-split.mjs --index large-doc.md ./references/
 ```
 
 ## Scripts
@@ -39,7 +39,7 @@ Download webpages and convert to Markdown, or recursively download website secti
 | `download-markdown.cjs` | Download single URL, convert to Markdown |
 | `html-to-markdown-recursive.cjs` | Convert existing HTML files to Markdown |
 | `website-download-recursive.sh` | Recursively download website with wget |
-| `markdown-split.cjs` | Split large Markdown into smaller reference files |
+| `markdown-split.mjs` | Split large Markdown into smaller reference files |
 
 ## Dependencies
 
@@ -241,7 +241,7 @@ Large markdown files (>20KB) can exceed context windows. Split them for progress
 
 ```sh
 # See structure before splitting
-./scripts/markdown-split.cjs --toc large-api-doc.md
+./scripts/markdown-split.mjs --toc large-api-doc.md
 ```
 
 Output:
@@ -260,13 +260,13 @@ Output:
 
 ```sh
 # Split on level-2 headers, create index
-./scripts/markdown-split.cjs --index --depth 2 large-api-doc.md ./api/
+./scripts/markdown-split.mjs --index --depth 2 large-api-doc.md ./api/
 
 # Flatten into numbered files
-./scripts/markdown-split.cjs --flatten large-guide.md ./guide/
+./scripts/markdown-split.mjs --flatten large-guide.md ./guide/
 
 # Custom size limits
-./scripts/markdown-split.cjs --max-lines 300 --max-bytes 15000 large.md ./split/
+./scripts/markdown-split.mjs --max-lines 300 --max-bytes 15000 large.md ./split/
 ```
 
 ### Options
@@ -326,7 +326,7 @@ Split for progressive context loading. Read only what you need.
   ./large-api.md
 
 # 3. Split for skill context loading
-./scripts/markdown-split.cjs --index ./large-api.md ./references/
+./scripts/markdown-split.mjs --index ./large-api.md ./references/
 ```
 
 ## Complete Workflow
@@ -356,7 +356,7 @@ Split for progressive context loading. Read only what you need.
   ./nmi/markdown
 
 # 4. Split large files for context loading
-./scripts/markdown-split.cjs --index ./nmi/markdown/large-api.md ./nmi/references/
+./scripts/markdown-split.mjs --index ./nmi/markdown/large-api.md ./nmi/references/
 ```
 
 ### API Reference Download
@@ -495,10 +495,10 @@ Split before loading into context:
 
 ```sh
 # View structure
-./scripts/markdown-split.cjs --toc large-doc.md
+./scripts/markdown-split.mjs --toc large-doc.md
 
 # Split into manageable chunks
-./scripts/markdown-split.cjs --index --max-lines 300 large-doc.md ./split/
+./scripts/markdown-split.mjs --index --max-lines 300 large-doc.md ./split/
 ```
 
 ## Script Versions
@@ -506,6 +506,6 @@ Split before loading into context:
 - `download-markdown.cjs`: 1.0.0
 - `html-to-markdown-recursive.cjs`: 1.0.0
 - `website-download-recursive.sh`: 1.0.0
-- `markdown-split.cjs`: 1.0.0
+- `markdown-split.mjs`: 1.0.0
 
 Bump versions when updating scripts.

--- a/download-markdown/SKILL.md
+++ b/download-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: download-markdown
-description: Download webpages and convert to Markdown, or recursively download website sections. Use when saving documentation for offline use, converting HTML documentation to Markdown, archiving web content, or processing API documentation. Covers URL downloading, HTML conversion, recursive downloads, and markdown detection with Accept headers and .md extensions.
+description: Download webpages and convert to Markdown, or recursively download website sections. Use when saving documentation for offline use, converting HTML documentation to Markdown, archiving web content, or processing API documentation. Covers URL downloading, HTML conversion, recursive downloads, markdown detection, and splitting large files for context loading.
 ---
 
 # Download Markdown
@@ -24,6 +24,12 @@ Download webpages and convert to Markdown, or recursively download website secti
 
 # Convert downloaded HTML to Markdown
 ./scripts/html-to-markdown-recursive.cjs ./downloaded ./markdown-docs
+
+# View TOC of large markdown file
+./scripts/markdown-split.cjs --toc large-doc.md
+
+# Split large file for skill context loading
+./scripts/markdown-split.cjs --index large-doc.md ./references/
 ```
 
 ## Scripts
@@ -33,6 +39,7 @@ Download webpages and convert to Markdown, or recursively download website secti
 | `download-markdown.cjs` | Download single URL, convert to Markdown |
 | `html-to-markdown-recursive.cjs` | Convert existing HTML files to Markdown |
 | `website-download-recursive.sh` | Recursively download website with wget |
+| `markdown-split.cjs` | Split large Markdown into smaller reference files |
 
 ## Dependencies
 
@@ -226,6 +233,102 @@ After downloading with wget, convert to Markdown:
   ./markdown-docs
 ```
 
+## 4. Split Large Markdown for Context Loading
+
+Large markdown files (>20KB) can exceed context windows. Split them for progressive disclosure.
+
+### View TOC with Line Numbers
+
+```sh
+# See structure before splitting
+./scripts/markdown-split.cjs --toc large-api-doc.md
+```
+
+Output:
+```
+| Level | Line | Header |
+|-------|------|--------|
+| 1 | 1 | API Reference |
+| 2 | 15 | Authentication |
+| 2 | 89 | Users |
+| 3 | 95 | List Users |
+| 3 | 142 | Create User |
+...
+```
+
+### Split into Smaller Files
+
+```sh
+# Split on level-2 headers, create index
+./scripts/markdown-split.cjs --index --depth 2 large-api-doc.md ./api/
+
+# Flatten into numbered files
+./scripts/markdown-split.cjs --flatten large-guide.md ./guide/
+
+# Custom size limits
+./scripts/markdown-split.cjs --max-lines 300 --max-bytes 15000 large.md ./split/
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--toc` | Output TOC with line numbers only |
+| `--index` | Create INDEX.md listing all splits |
+| `--depth N` | Header depth to split on (default: 2) |
+| `--max-lines N` | Target max lines per file (default: 500) |
+| `--max-bytes N` | Target max bytes per file (default: 20000) |
+| `--flatten` | Use flat numbered filenames |
+
+### Output Structure
+
+**Before splitting:**
+```
+large-api-doc.md  (150KB, 3000 lines)
+```
+
+**After splitting:**
+```
+api/
+├── INDEX.md
+├── authentication.md
+├── users.md
+├── projects.md
+└── webhooks.md
+```
+
+**INDEX.md:**
+```markdown
+# API Reference
+
+Split for progressive context loading. Read only what you need.
+
+| File | Header | Lines | Size |
+|------|--------|-------|------|
+| authentication.md | Authentication | 89 | 4.2KB |
+| users.md | Users | 245 | 12.1KB |
+| projects.md | Projects | 178 | 8.5KB |
+| webhooks.md | Webhooks | 112 | 5.8KB |
+```
+
+### Workflow: Download → Convert → Split
+
+```sh
+# 1. Download large documentation
+./scripts/website-download-recursive.sh \
+  --depth 3 \
+  https://docs.example.com/api \
+  ./downloaded
+
+# 2. Convert to single large markdown
+./scripts/html-to-markdown-recursive.cjs \
+  ./downloaded \
+  ./large-api.md
+
+# 3. Split for skill context loading
+./scripts/markdown-split.cjs --index ./large-api.md ./references/
+```
+
 ## Complete Workflow
 
 ### Archive Documentation Site (Smart Detection)
@@ -251,6 +354,9 @@ After downloading with wget, convert to Markdown:
   --frontmatter \
   ./nmi/html \
   ./nmi/markdown
+
+# 4. Split large files for context loading
+./scripts/markdown-split.cjs --index ./nmi/markdown/large-api.md ./nmi/references/
 ```
 
 ### API Reference Download
@@ -316,6 +422,15 @@ markdown-docs/
     └── getting-started.md
 ```
 
+**After Splitting:**
+```
+references/
+├── INDEX.md
+├── authentication.md
+├── users.md
+└── projects.md
+```
+
 ## Frontmatter
 
 With `--frontmatter`, generated files include:
@@ -374,10 +489,23 @@ Increase wait time:
 ./scripts/website-download-recursive.sh --wait 5 https://example.com/docs
 ```
 
+### Large files exceed context
+
+Split before loading into context:
+
+```sh
+# View structure
+./scripts/markdown-split.cjs --toc large-doc.md
+
+# Split into manageable chunks
+./scripts/markdown-split.cjs --index --max-lines 300 large-doc.md ./split/
+```
+
 ## Script Versions
 
-- `download-markdown.js`: 1.0.0
-- `html-to-markdown-recursive.js`: 1.0.0
+- `download-markdown.cjs`: 1.0.0
+- `html-to-markdown-recursive.cjs`: 1.0.0
 - `website-download-recursive.sh`: 1.0.0
+- `markdown-split.cjs`: 1.0.0
 
 Bump versions when updating scripts.

--- a/download-markdown/scripts/download-markdown.cjs
+++ b/download-markdown/scripts/download-markdown.cjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+/**
+ * Download a webpage and convert to Markdown
+ * Uses @mozilla/readability for content extraction and turndown for HTML-to-MD conversion
+ *
+ * Version: 1.0.0
+ * When updating this script, bump the version number above.
+ */
+
+const fs = require('fs').promises;
+const path = require('path');
+const https = require('https');
+const http = require('http');
+const { URL } = require('url');
+
+// Try to load optional dependencies
+let Readability = null;
+let TurndownService = null;
+let JSDOM = null;
+
+try {
+    const { Readability: R } = require('@mozilla/readability');
+    Readability = R;
+} catch (e) {
+    // Will be checked later
+}
+
+try {
+    const Turndown = require('turndown');
+    TurndownService = Turndown;
+} catch (e) {
+    // Will be checked later
+}
+
+try {
+    const { JSDOM: J } = require('jsdom');
+    JSDOM = J;
+} catch (e) {
+    // Will be checked later
+}
+
+const VERSION = '1.0.0';
+
+function showHelp() {
+    console.log(`
+Usage: download-markdown.cjs [OPTIONS] <url> [output]
+
+Download a webpage and convert to Markdown.
+
+ARGUMENTS:
+    url         The URL to download
+    output      Output file path (optional, defaults to stdout)
+
+OPTIONS:
+    -h, --help      Show this help message
+    -v, --version   Show version information
+    --detect-md     Check if site serves Markdown directly first
+    --no-readability    Skip readability extraction (convert full HTML)
+    --frontmatter   Add YAML frontmatter with metadata
+
+EXAMPLES:
+    # Download to stdout
+    download-markdown.cjs https://example.com/article
+
+    # Save to file
+    download-markdown.cjs https://example.com/article ./output.md
+
+    # Detect if site serves markdown first
+    download-markdown.cjs --detect-md https://docs.example.com/page
+
+DEPENDENCIES:
+    npm install @mozilla/readability turndown jsdom
+`);
+}
+
+function showVersion() {
+    console.log(`download-markdown.cjs version ${VERSION}`);
+    console.log('Download webpages and convert to Markdown');
+}
+
+async function fetchUrl(url, options = {}) {
+    const headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+    };
+
+    if (options.acceptMarkdown) {
+        headers['Accept'] = 'text/markdown, text/plain, */*';
+    }
+
+    return new Promise((resolve, reject) => {
+        const client = url.startsWith('https:') ? https : http;
+        const req = client.get(url, { headers }, (res) => {
+            if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                const redirectUrl = new URL(res.headers.location, url).toString();
+                console.error(`Redirecting to: ${redirectUrl}`);
+                fetchUrl(redirectUrl, options).then(resolve).catch(reject);
+                return;
+            }
+
+            if (res.statusCode !== 200) {
+                reject(new Error(`HTTP ${res.statusCode}`));
+                return;
+            }
+
+            let data = '';
+            res.setEncoding('utf8');
+            res.on('data', chunk => data += chunk);
+            res.on('end', () => {
+                resolve({
+                    content: data,
+                    contentType: res.headers['content-type'] || '',
+                    finalUrl: res.responseUrl || url
+                });
+            });
+        });
+
+        req.on('error', reject);
+        req.setTimeout(30000, () => {
+            req.destroy();
+            reject(new Error('Request timeout'));
+        });
+    });
+}
+
+function extractMarkdownLinks(html, baseUrl) {
+    const links = [];
+
+    // Simple regex-based extraction (faster than full JSDOM parse)
+    const linkRegex = /<a\s+(?:[^>]*?\s+)?href=(["'])([^"']+\.md(?:[^"']*)?)\1[^>]*>/gi;
+    let match;
+
+    while ((match = linkRegex.exec(html)) !== null) {
+        const href = match[2];
+        try {
+            const absoluteUrl = new URL(href, baseUrl).toString();
+            links.push({
+                url: absoluteUrl,
+                type: 'markdown-link'
+            });
+        } catch (e) {
+            // Skip invalid URLs
+        }
+    }
+
+    // Also look for edit/source links (common pattern in docs)
+    const editLinkRegex = /<a\s+(?:[^>]*?\s+)?(?:rel=["'](?:edit|source|edit-this-page|view-source)["']|class=["'][^"']*edit[^"']*["'])(?:[^>]*?\s+)?href=(["'])([^"']+)["'][^>]*>(?:Edit|View Source|Edit this page)/gi;
+
+    while ((match = editLinkRegex.exec(html)) !== null) {
+        const href = match[3];
+        try {
+            const absoluteUrl = new URL(href, baseUrl).toString();
+            links.push({
+                url: absoluteUrl,
+                type: 'edit-link'
+            });
+        } catch (e) {
+            // Skip invalid URLs
+        }
+    }
+
+    // Look for GitHub/GitLab raw links
+    const rawLinkRegex = /<a\s+(?:[^>]*?\s+)?href=(["'])(https?://(?:raw\.github(?:user)?\.com|gitlab\.com/[^/]+/[^/]+/-/raw)[^"']+)(?:\.md)?(?:[^"']*)\1/gi;
+
+    while ((match = rawLinkRegex.exec(html)) !== null) {
+        const href = match[2];
+        try {
+            const absoluteUrl = new URL(href, baseUrl).toString();
+            links.push({
+                url: absoluteUrl,
+                type: 'raw-link'
+            });
+        } catch (e) {
+            // Skip invalid URLs
+        }
+    }
+
+    return links;
+}
+
+async function tryFetchMarkdown(url) {
+    const urlObj = new URL(url);
+    const basePath = urlObj.pathname.replace(/\/?$/, '');
+
+    const strategies = [
+        { name: '.md extension', url: `${basePath}.md` },
+        { name: '.markdown extension', url: `${basePath}.markdown` },
+        { name: '/index.md', url: `${basePath}/index.md` },
+        { name: '.html → .md', url: basePath.replace(/\.html?$/, '.md') },
+        { name: '/README.md', url: `${basePath}/README.md` },
+    ];
+
+    const results = {
+        tried: [],
+        found: null,
+        htmlLinks: []
+    };
+
+    // Try each URL variant
+    for (const strategy of strategies) {
+        const testUrl = new URL(strategy.url, url).toString();
+        results.tried.push({ name: strategy.name, url: testUrl });
+
+        try {
+            const result = await fetchUrl(testUrl);
+            const isMarkdown = result.contentType.includes('text/markdown') ||
+                              result.contentType.includes('text/x-markdown') ||
+                              (result.contentType.includes('text/plain') &&
+                               (result.content.trim().startsWith('#') ||
+                                result.content.includes('---\n') ||
+                                /\[.*\]\(.*\)/.test(result.content)));
+
+            if (isMarkdown || result.content.trim().startsWith('#')) {
+                results.found = { url: testUrl, content: result.content, contentType: result.contentType };
+                return results;
+            }
+        } catch (e) {
+            // Try next
+        }
+    }
+
+    // Try Accept header on original URL
+    try {
+        const result = await fetchUrl(url, { acceptMarkdown: true });
+        const isMarkdown = result.contentType.includes('text/markdown') ||
+                          result.contentType.includes('text/x-markdown');
+
+        if (isMarkdown) {
+            results.found = { url, content: result.content, contentType: result.contentType };
+            return results;
+        }
+
+        // Parse HTML for markdown links
+        if (JSDOM) {
+            const mdLinks = extractMarkdownLinks(result.content, url);
+            if (mdLinks.length > 0) {
+                results.htmlLinks = mdLinks;
+                console.error(`Found ${mdLinks.length} potential Markdown link(s) in HTML`);
+
+                // Try the first markdown link
+                for (const link of mdLinks.slice(0, 2)) {
+                    try {
+                        const mdResult = await fetchUrl(link.url);
+                        if (mdResult.contentType.includes('text/markdown') ||
+                            mdResult.contentType.includes('text/x-markdown') ||
+                            mdResult.content.trim().startsWith('#')) {
+                            results.found = { url: link.url, content: mdResult.content, contentType: mdResult.contentType };
+                            console.error(`Found Markdown via ${link.type} link: ${link.url}`);
+                            return results;
+                        }
+                    } catch (e) {
+                        // Try next
+                    }
+                }
+            }
+        }
+    } catch (e) {
+        // Fall through
+    }
+
+    return results;
+}
+
+function extractWithReadability(html, url) {
+    if (!Readability || !JSDOM) {
+        throw new Error('Readability extraction requires @mozilla/readability and jsdom');
+    }
+
+    const dom = new JSDOM(html, { url });
+    const reader = new Readability(dom.window.document);
+    const article = reader.parse();
+
+    if (!article) {
+        return null;
+    }
+
+    return {
+        title: article.title,
+        byline: article.byline,
+        content: article.content,
+        textContent: article.textContent,
+        excerpt: article.excerpt
+    };
+}
+
+function htmlToMarkdown(html, title) {
+    if (!TurndownService) {
+        throw new Error('HTML to Markdown conversion requires turndown');
+    }
+
+    const turndown = new TurndownService({
+        headingStyle: 'atx',
+        bulletListMarker: '-',
+        codeBlockStyle: 'fenced'
+    });
+
+    turndown.addRule('preserveLineBreaks', {
+        filter: 'br',
+        replacement: () => '\n'
+    });
+
+    turndown.remove(['script', 'style', 'nav', 'header', 'footer', 'aside']);
+
+    const markdown = turndown.turndown(html);
+    return markdown.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+
+    if (args.length === 0) {
+        showHelp();
+        process.exit(1);
+    }
+
+    let detectMd = false;
+    let useReadability = true;
+    let addFrontmatter = false;
+    let url = null;
+    let outputPath = null;
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        switch (arg) {
+            case '-h':
+            case '--help':
+            case 'help':
+                showHelp();
+                process.exit(0);
+                break;
+            case '-v':
+            case '--version':
+            case '-version':
+            case 'version':
+                showVersion();
+                process.exit(0);
+                break;
+            case '--detect-md':
+                detectMd = true;
+                break;
+            case '--no-readability':
+                useReadability = false;
+                break;
+            case '--frontmatter':
+                addFrontmatter = true;
+                break;
+            default:
+                if (!arg.startsWith('-')) {
+                    if (!url) url = arg;
+                    else if (!outputPath) outputPath = arg;
+                } else {
+                    console.error(`Unknown option: ${arg}`);
+                    process.exit(1);
+                }
+        }
+    }
+
+    if (!url) {
+        console.error('Error: URL is required');
+        showHelp();
+        process.exit(1);
+    }
+
+    try {
+        console.error(`Fetching: ${url}`);
+
+        if (detectMd) {
+            console.error('Checking for Markdown variants...');
+            const mdResults = await tryFetchMarkdown(url);
+
+            if (mdResults.found) {
+                console.error(`Found Markdown at: ${mdResults.found.url}`);
+                console.error(`Content-Type: ${mdResults.found.contentType}`);
+                let content = mdResults.found.content;
+
+                if (addFrontmatter) {
+                    const frontmatter = `---\ntitle: "${path.basename(url)}"\nsource: "${mdResults.found.url}"\ndate: "${new Date().toISOString()}"\n---\n\n`;
+                    content = frontmatter + content;
+                }
+
+                if (outputPath) {
+                    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+                    await fs.writeFile(outputPath, content, 'utf8');
+                    console.error(`Saved to: ${outputPath}`);
+                } else {
+                    console.log(content);
+                }
+                return;
+            }
+
+            console.error('Tried:');
+            for (const attempt of mdResults.tried) {
+                console.error(`  ${attempt.name}: ${attempt.url}`);
+            }
+
+            if (mdResults.htmlLinks.length > 0) {
+                console.error(`Found ${mdResults.htmlLinks.length} Markdown link(s) in HTML (none worked):`);
+                for (const link of mdResults.htmlLinks) {
+                    console.error(`  [${link.type}] ${link.url}`);
+                }
+            }
+
+            console.error('No Markdown version found, converting HTML...');
+        }
+
+        const result = await fetchUrl(url);
+
+        let markdown = '';
+        let metadata = {
+            title: '',
+            byline: '',
+            source: result.finalUrl || url,
+            date: new Date().toISOString()
+        };
+
+        if (useReadability && Readability) {
+            console.error('Extracting content with Readability...');
+            const article = extractWithReadability(result.content, url);
+
+            if (article) {
+                metadata.title = article.title || '';
+                metadata.byline = article.byline || '';
+                markdown = htmlToMarkdown(article.content, article.title);
+            } else {
+                console.error('Readability extraction failed, converting full HTML...');
+                metadata.title = 'Untitled';
+                markdown = htmlToMarkdown(result.content, '');
+            }
+        } else {
+            console.error('Converting full HTML...');
+            const titleMatch = result.content.match(/<title[^>]*>([^<]*)<\/title>/i);
+            metadata.title = titleMatch ? titleMatch[1].trim() : '';
+            markdown = htmlToMarkdown(result.content, metadata.title);
+        }
+
+        if (addFrontmatter) {
+            const frontmatter = `---\ntitle: "${metadata.title}"\nbyline: "${metadata.byline}"\nsource: "${metadata.source}"\ndate: "${metadata.date}"\n---\n\n`;
+            markdown = frontmatter + markdown;
+        }
+
+        if (outputPath) {
+            await fs.mkdir(path.dirname(outputPath), { recursive: true });
+            await fs.writeFile(outputPath, markdown, 'utf8');
+            console.error(`Saved to: ${outputPath}`);
+        } else {
+            console.log(markdown);
+        }
+
+    } catch (error) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+    }
+}
+
+main();

--- a/download-markdown/scripts/html-to-markdown-recursive.cjs
+++ b/download-markdown/scripts/html-to-markdown-recursive.cjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+/**
+ * Recursively convert HTML files to Markdown
+ * Preserves directory structure
+ *
+ * Version: 1.0.0
+ * When updating this script, bump the version number above.
+ */
+
+const fs = require('fs').promises;
+const path = require('path');
+const { exec } = require('child_process');
+const { promisify } = require('util');
+
+const execAsync = promisify(exec);
+
+// Try to load optional dependencies
+let TurndownService = null;
+try {
+    const Turndown = require('turndown');
+    TurndownService = Turndown;
+} catch (e) {
+    // Will be checked later
+}
+
+let JSDOM = null;
+try {
+    const { JSDOM: J } = require('jsdom');
+    JSDOM = J;
+} catch (e) {
+    // Will be checked later
+}
+
+const VERSION = '1.0.0';
+
+function showHelp() {
+    console.log(`
+Usage: html-to-markdown-recursive.js [OPTIONS] <input> <output>
+
+Recursively convert HTML files to Markdown, preserving directory structure.
+
+ARGUMENTS:
+    input       Input directory or file path
+    output      Output directory
+
+OPTIONS:
+    -h, --help          Show this help message
+    -v, --version       Show version information
+    --clean             Remove original HTML files after conversion
+    --flatten           Flatten output structure (all files in one dir)
+    --strip-prefix      Strip common prefix from output paths
+    --dry-run           Show what would be converted without doing it
+    --frontmatter       Add YAML frontmatter with metadata
+    --no-readability    Convert full HTML without content extraction
+
+EXAMPLES:
+    # Convert directory
+    html-to-markdown-recursive.js ./docs ./markdown-docs
+
+    # Convert single file
+    html-to-markdown-recursive.js ./article.html ./articles/article.md
+
+    # Preview changes
+    html-to-markdown-recursive.js --dry-run ./docs ./markdown-docs
+
+    # Clean up HTML after conversion
+    html-to-markdown-recursive.js --clean ./docs ./markdown-docs
+
+DEPENDENCIES:
+    npm install turndown jsdom
+`);
+}
+
+function showVersion() {
+    console.log(`html-to-markdown-recursive.js version ${VERSION}`);
+    console.log('Recursively convert HTML files to Markdown');
+}
+
+async function findHtmlFiles(inputPath) {
+    const files = [];
+
+    async function walk(dir) {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+
+        for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                await walk(fullPath);
+            } else if (entry.isFile() && entry.name.endsWith('.html')) {
+                files.push(fullPath);
+            }
+        }
+    }
+
+    const stat = await fs.stat(inputPath);
+    if (stat.isDirectory()) {
+        await walk(inputPath);
+    } else if (stat.isFile() && inputPath.endsWith('.html')) {
+        files.push(inputPath);
+    }
+
+    return files;
+}
+
+function htmlToMarkdown(html, title) {
+    if (!TurndownService) {
+        throw new Error('HTML to Markdown conversion requires turndown');
+    }
+
+    const turndown = new TurndownService({
+        headingStyle: 'atx',
+        bulletListMarker: '-',
+        codeBlockStyle: 'fenced',
+        emDelimiter: '*'
+    });
+
+    // Configure rules
+    turndown.addRule('preserveLineBreaks', {
+        filter: 'br',
+        replacement: () => '\n'
+    });
+
+    turndown.remove(['script', 'style']);
+
+    const markdown = turndown.turndown(html);
+
+    // Clean up
+    return markdown.replace(/\n{3,}/g, '\n\n').trim();
+}
+
+async function extractContentWithReadability(html, filePath) {
+    if (!JSDOM) {
+        return null;
+    }
+
+    try {
+        const dom = new JSDOM(html, { url: `file://${filePath}` });
+        const { Readability } = require('@mozilla/readability');
+        const reader = new Readability(dom.window.document);
+        const article = reader.parse();
+
+        if (article && article.textContent.length > 100) {
+            return {
+                title: article.title,
+                content: article.content,
+                textContent: article.textContent
+            };
+        }
+    } catch (e) {
+        console.error(`Readability failed for ${filePath}: ${e.message}`);
+    }
+
+    return null;
+}
+
+async function convertFile(inputFile, outputFile, options) {
+    const html = await fs.readFile(inputFile, 'utf8');
+
+    let title = '';
+    let content = html;
+
+    // Try readability extraction if enabled
+    if (options.useReadability) {
+        const extracted = await extractContentWithReadability(html, inputFile);
+        if (extracted) {
+            title = extracted.title || '';
+            content = extracted.content;
+        } else {
+            // Extract title from HTML
+            const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+            title = titleMatch ? titleMatch[1].trim() : '';
+        }
+    } else {
+        // Extract title from HTML
+        const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i);
+        title = titleMatch ? titleMatch[1].trim() : '';
+    }
+
+    let markdown = htmlToMarkdown(content, title);
+
+    // Add frontmatter if requested
+    if (options.frontmatter) {
+        const frontmatter = `---\ntitle: "${title}"\nsource: "${inputFile}"\nconverted: "${new Date().toISOString()}"\n---\n\n`;
+        markdown = frontmatter + markdown;
+    }
+
+    // Ensure output directory exists
+    await fs.mkdir(path.dirname(outputFile), { recursive: true });
+
+    // Write markdown file
+    await fs.writeFile(outputFile, markdown, 'utf8');
+
+    // Clean up original if requested
+    if (options.clean) {
+        await fs.unlink(inputFile);
+    }
+
+    return { title, input: inputFile, output: outputFile };
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+
+    if (args.length < 2) {
+        showHelp();
+        process.exit(1);
+    }
+
+    let inputPath = null;
+    let outputPath = null;
+    let options = {
+        clean: false,
+        flatten: false,
+        stripPrefix: false,
+        dryRun: false,
+        frontmatter: false,
+        useReadability: true
+    };
+
+    // Parse arguments
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        switch (arg) {
+            case '-h':
+            case '--help':
+            case 'help':
+                showHelp();
+                process.exit(0);
+                break;
+            case '-v':
+            case '--version':
+            case '-version':
+            case 'version':
+                showVersion();
+                process.exit(0);
+                break;
+            case '--clean':
+                options.clean = true;
+                break;
+            case '--flatten':
+                options.flatten = true;
+                break;
+            case '--strip-prefix':
+                options.stripPrefix = true;
+                break;
+            case '--dry-run':
+                options.dryRun = true;
+                break;
+            case '--frontmatter':
+                options.frontmatter = true;
+                break;
+            case '--no-readability':
+                options.useReadability = false;
+                break;
+            default:
+                if (!arg.startsWith('-')) {
+                    if (!inputPath) {
+                        inputPath = arg;
+                    } else if (!outputPath) {
+                        outputPath = arg;
+                    }
+                } else {
+                    console.error(`Unknown option: ${arg}`);
+                    process.exit(1);
+                }
+        }
+    }
+
+    if (!inputPath || !outputPath) {
+        console.error('Error: input and output paths are required');
+        showHelp();
+        process.exit(1);
+    }
+
+    // Check dependencies
+    if (!TurndownService) {
+        console.error('Error: turndown is required. Run: npm install turndown');
+        process.exit(1);
+    }
+
+    try {
+        // Resolve paths
+        const resolvedInput = path.resolve(inputPath);
+        const resolvedOutput = path.resolve(outputPath);
+
+        console.error(`Scanning for HTML files in: ${resolvedInput}`);
+
+        const htmlFiles = await findHtmlFiles(resolvedInput);
+
+        if (htmlFiles.length === 0) {
+            console.error('No HTML files found.');
+            process.exit(0);
+        }
+
+        console.error(`Found ${htmlFiles.length} HTML file(s)`);
+
+        if (options.dryRun) {
+            console.log('\nDry run - would convert:');
+        }
+
+        const results = [];
+        const inputDir = (await fs.stat(resolvedInput)).isDirectory()
+            ? resolvedInput
+            : path.dirname(resolvedInput);
+
+        for (const file of htmlFiles) {
+            let relativePath = path.relative(inputDir, file);
+            let outputFile;
+
+            if (options.flatten) {
+                // Flatten: just use basename
+                const base = path.basename(file, '.html') + '.md';
+                outputFile = path.join(resolvedOutput, base);
+            } else if (options.stripPrefix) {
+                // Strip common directory prefix
+                const parts = relativePath.split(path.sep);
+                if (parts.length > 1) {
+                    relativePath = parts.slice(1).join(path.sep);
+                }
+                outputFile = path.join(resolvedOutput, relativePath.replace('.html', '.md'));
+            } else {
+                // Preserve structure
+                outputFile = path.join(resolvedOutput, relativePath.replace('.html', '.md'));
+            }
+
+            if (options.dryRun) {
+                console.log(`  ${file} -> ${outputFile}`);
+                continue;
+            }
+
+            try {
+                const result = await convertFile(file, outputFile, options);
+                results.push(result);
+                console.error(`✓ ${path.basename(file)} -> ${outputFile}`);
+            } catch (e) {
+                console.error(`✗ ${file}: ${e.message}`);
+            }
+        }
+
+        if (!options.dryRun) {
+            console.error(`\nConverted ${results.length} file(s)`);
+        }
+
+    } catch (error) {
+        console.error(`Error: ${error.message}`);
+        process.exit(1);
+    }
+}
+
+main();

--- a/download-markdown/scripts/markdown-split.cjs
+++ b/download-markdown/scripts/markdown-split.cjs
@@ -1,0 +1,438 @@
+#!/usr/bin/env node
+/**
+ * Split large Markdown files into smaller reference files
+ * Extracts TOC, splits by headers, creates navigation index
+ *
+ * Version: 1.0.0
+ * When updating this script, bump the version number above.
+ */
+
+const fs = require('fs').promises;
+const path = require('path');
+
+const VERSION = '1.0.0';
+
+function showHelp() {
+    console.log(`
+Usage: markdown-split.cjs [OPTIONS] <input> [output-dir]
+
+Split large Markdown files into smaller reference files for skill context loading.
+
+ARGUMENTS:
+    input       Input markdown file
+    output-dir  Output directory (defaults to input name without .md)
+
+OPTIONS:
+    -h, --help          Show this help message
+    -v, --version       Show version information
+    --toc               Output TOC with line numbers only
+    --max-lines N       Target max lines per file (default: 500)
+    --max-bytes N       Target max bytes per file (default: 20000)
+    --depth N           Header depth to split on (default: 2, splits on ##)
+    --index             Create index file listing all splits
+    --flatten           Use flat filenames instead of directories
+
+EXAMPLES:
+    # View TOC with line numbers
+    markdown-split.cjs --toc large-doc.md
+
+    # Split into directory
+    markdown-split.cjs --index large-doc.md ./references/
+
+    # Split on level-1 headers, flatten filenames
+    markdown-split.cjs --depth 1 --flatten large-api.md ./api/
+
+OUTPUT:
+    Creates multiple .md files suitable for progressive context loading.
+    Each file starts with a header and stays within size limits.
+`);
+}
+
+function showVersion() {
+    console.log(`markdown-split.cjs version ${VERSION}`);
+    console.log('Split large Markdown files for skill context loading');
+}
+
+/**
+ * Extract headers from markdown content
+ * @param {string} content - Markdown content
+ * @param {number} maxDepth - Maximum header depth (1-6)
+ * @returns {Array<{level: number, text: string, line: number, slug: string}>}
+ */
+function extractHeaders(content, maxDepth = 6) {
+    const lines = content.split('\n');
+    const headers = [];
+    let inCodeBlock = false;
+    let startLine = 0;
+
+    // Skip YAML frontmatter
+    if (lines[0] === '---') {
+        for (let i = 1; i < lines.length; i++) {
+            if (lines[i] === '---') {
+                startLine = i + 1;
+                break;
+            }
+        }
+    }
+
+    for (let i = startLine; i < lines.length; i++) {
+        const line = lines[i];
+
+        // Track code blocks
+        if (line.trim().startsWith('```')) {
+            inCodeBlock = !inCodeBlock;
+            continue;
+        }
+
+        // Skip lines inside code blocks
+        if (inCodeBlock) continue;
+
+        // ATX-style headers (# Header)
+        const atxMatch = line.match(/^(#{1,6})\s+(.+)$/);
+        if (atxMatch) {
+            const level = atxMatch[1].length;
+            if (level <= maxDepth) {
+                headers.push({
+                    level,
+                    text: atxMatch[2].trim(),
+                    line: i + 1,
+                    slug: slugify(atxMatch[2].trim())
+                });
+            }
+        }
+
+        // Setext-style headers (underlined with = or -)
+        if (i > 0 && lines[i - 1].trim()) {
+            const prevLine = lines[i - 1];
+            if (line.match(/^=+$/) && prevLine.trim()) {
+                // Level 1 (underlined with =)
+                headers.push({
+                    level: 1,
+                    text: prevLine.trim(),
+                    line: i,
+                    slug: slugify(prevLine.trim())
+                });
+            } else if (line.match(/^-+$/) && prevLine.trim()) {
+                // Level 2 (underlined with -)
+                headers.push({
+                    level: 2,
+                    text: prevLine.trim(),
+                    line: i,
+                    slug: slugify(prevLine.trim())
+                });
+            }
+        }
+    }
+
+    return headers;
+}
+
+/**
+ * Convert text to URL-safe slug
+ * @param {string} text - Header text
+ * @returns {string}
+ */
+function slugify(text) {
+    return text
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .substring(0, 50);
+}
+
+/**
+ * Generate a safe filename from header
+ * @param {object} header - Header object
+ * @param {number} index - Header index
+ * @param {boolean} flatten - Use flat names
+ * @returns {string}
+ */
+function headerToFilename(header, index, flatten = false) {
+    const slug = header.slug || slugify(header.text);
+
+    if (flatten) {
+        return `${String(index).padStart(3, '0')}-${slug}.md`;
+    }
+
+    // Create hierarchical filename based on header depth
+    return `${slug}.md`;
+}
+
+/**
+ * Output TOC with line numbers
+ * @param {string} content - Markdown content
+ * @param {number} maxDepth - Maximum header depth
+ */
+function outputTOC(content, maxDepth = 6) {
+    const headers = extractHeaders(content, maxDepth);
+
+    console.log('# Table of Contents\n');
+    console.log('| Level | Line | Header |');
+    console.log('|-------|------|--------|');
+
+    for (const h of headers) {
+        const indent = '  '.repeat(h.level - 1);
+        console.log(`| ${h.level} | ${h.line} | ${indent}${h.text} |`);
+    }
+
+    console.log('\n---\n');
+    console.log(`Total headers: ${headers.length}`);
+    console.log(`Total lines: ${content.split('\n').length}`);
+}
+
+/**
+ * Split markdown by headers
+ * @param {string} content - Markdown content
+ * @param {object} options - Split options
+ * @returns {Array<{name: string, content: string, header: object}>}
+ */
+function splitByHeader(content, options = {}) {
+    const {
+        splitDepth = 2,
+        maxLines = 500,
+        maxBytes = 20000,
+        flatten = false
+    } = options;
+
+    const lines = content.split('\n');
+    const headers = extractHeaders(content, splitDepth);
+    const sections = [];
+
+    if (headers.length === 0) {
+        // No headers at this depth, return entire content
+        return [{ name: 'index.md', content, header: null }];
+    }
+
+    // Add implicit start if content before first header
+    const firstHeaderLine = headers[0].line - 1;
+    if (firstHeaderLine > 0) {
+        const preamble = lines.slice(0, firstHeaderLine).join('\n');
+        if (preamble.trim()) {
+            sections.push({
+                name: 'intro.md',
+                content: preamble,
+                header: { text: 'Introduction', level: 0 }
+            });
+        }
+    }
+
+    // Split by headers at splitDepth
+    for (let i = 0; i < headers.length; i++) {
+        const header = headers[i];
+        const startLine = header.line - 1;
+        const endLine = i < headers.length - 1
+            ? headers[i + 1].line - 1
+            : lines.length;
+
+        const sectionLines = lines.slice(startLine, endLine);
+        const sectionContent = sectionLines.join('\n');
+
+        // Check if section is too large and needs further splitting
+        if (sectionLines.length > maxLines || sectionContent.length > maxBytes) {
+            // Find subheaders within this section
+            const subHeaders = extractHeaders(sectionContent, splitDepth + 1)
+                .filter(h => h.level > header.level);
+
+            if (subHeaders.length > 0) {
+                // Split by subheaders
+                for (let j = 0; j < subHeaders.length; j++) {
+                    const subHeader = subHeaders[j];
+                    const subStart = subHeader.line - 1;
+                    const subEnd = j < subHeaders.length - 1
+                        ? subHeaders[j + 1].line - 1
+                        : sectionLines.length;
+
+                    const subContent = sectionLines.slice(subStart, subEnd).join('\n');
+
+                    sections.push({
+                        name: headerToFilename(subHeader, i * 100 + j, flatten),
+                        content: subContent,
+                        header: subHeader,
+                        parent: header.text
+                    });
+                }
+            } else {
+                // No subheaders, keep as-is but warn
+                sections.push({
+                    name: headerToFilename(header, i, flatten),
+                    content: sectionContent,
+                    header,
+                    oversized: true
+                });
+            }
+        } else {
+            sections.push({
+                name: headerToFilename(header, i, flatten),
+                content: sectionContent,
+                header
+            });
+        }
+    }
+
+    return sections;
+}
+
+/**
+ * Create index file listing all sections
+ * @param {Array} sections - Array of section objects
+ * @param {string} title - Index title
+ * @returns {string}
+ */
+function createIndex(sections, title = 'Reference Index') {
+    let index = `# ${title}\n\n`;
+    index += 'Split for progressive context loading. Read only what you need.\n\n';
+    index += '| File | Header | Lines | Size |\n';
+    index += '|------|--------|-------|------|\n';
+
+    for (const section of sections) {
+        const lines = section.content.split('\n').length;
+        const size = (section.content.length / 1024).toFixed(1);
+        const warning = section.oversized ? ' ⚠️' : '';
+        index += `| ${section.name} | ${section.header?.text || 'Introduction'} | ${lines} | ${size}KB${warning} |\n`;
+    }
+
+    index += '\n---\n';
+    index += 'Usage: Use `grep -n "^#" file.md` to find headers, then read specific sections.\n';
+
+    return index;
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+    const options = {
+        toc: false,
+        index: false,
+        splitDepth: 2,
+        maxLines: 500,
+        maxBytes: 20000,
+        flatten: false
+    };
+
+    let inputFile = null;
+    let outputDir = null;
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        if (arg === '-h' || arg === '--help') {
+            showHelp();
+            process.exit(0);
+        }
+
+        if (arg === '-v' || arg === '--version') {
+            showVersion();
+            process.exit(0);
+        }
+
+        if (arg === '--toc') {
+            options.toc = true;
+            continue;
+        }
+
+        if (arg === '--index') {
+            options.index = true;
+            continue;
+        }
+
+        if (arg === '--flatten') {
+            options.flatten = true;
+            continue;
+        }
+
+        if (arg === '--depth') {
+            options.splitDepth = parseInt(args[++i], 10);
+            continue;
+        }
+
+        if (arg === '--max-lines') {
+            options.maxLines = parseInt(args[++i], 10);
+            continue;
+        }
+
+        if (arg === '--max-bytes') {
+            options.maxBytes = parseInt(args[++i], 10);
+            continue;
+        }
+
+        if (!arg.startsWith('-')) {
+            if (!inputFile) {
+                inputFile = arg;
+            } else if (!outputDir) {
+                outputDir = arg;
+            }
+        }
+    }
+
+    if (!inputFile) {
+        console.error('Error: No input file specified');
+        console.error('Use --help for usage information');
+        process.exit(1);
+    }
+
+    // Read input file
+    let content;
+    try {
+        content = await fs.readFile(inputFile, 'utf-8');
+    } catch (e) {
+        console.error(`Error: Cannot read file: ${inputFile}`);
+        console.error(e.message);
+        process.exit(1);
+    }
+
+    // TOC mode - output and exit
+    if (options.toc) {
+        outputTOC(content, options.splitDepth);
+        process.exit(0);
+    }
+
+    // Default output dir to input name without extension
+    if (!outputDir) {
+        outputDir = inputFile.replace(/\.md$/, '');
+    }
+
+    // Split content
+    const sections = splitByHeader(content, options);
+
+    // Create output directory
+    try {
+        await fs.mkdir(outputDir, { recursive: true });
+    } catch (e) {
+        console.error(`Error: Cannot create directory: ${outputDir}`);
+        console.error(e.message);
+        process.exit(1);
+    }
+
+    // Write sections
+    for (const section of sections) {
+        const outputPath = path.join(outputDir, section.name);
+        try {
+            await fs.writeFile(outputPath, section.content);
+            const lines = section.content.split('\n').length;
+            const size = (section.content.length / 1024).toFixed(1);
+            console.log(`Wrote: ${section.name} (${lines} lines, ${size}KB)`);
+            if (section.oversized) {
+                console.log(`  ⚠️  Section exceeds size limits but has no subheaders`);
+            }
+        } catch (e) {
+            console.error(`Error: Cannot write file: ${outputPath}`);
+            console.error(e.message);
+        }
+    }
+
+    // Create index if requested
+    if (options.index) {
+        const title = path.basename(inputFile, '.md');
+        const indexContent = createIndex(sections, title);
+        const indexPath = path.join(outputDir, 'INDEX.md');
+        await fs.writeFile(indexPath, indexContent);
+        console.log(`Wrote: INDEX.md`);
+    }
+
+    console.log(`\nSplit ${inputFile} into ${sections.length} files in ${outputDir}/`);
+}
+
+main().catch(e => {
+    console.error('Error:', e.message);
+    process.exit(1);
+});

--- a/download-markdown/scripts/markdown-split.mjs
+++ b/download-markdown/scripts/markdown-split.mjs
@@ -7,14 +7,18 @@
  * When updating this script, bump the version number above.
  */
 
-const fs = require('fs').promises;
-const path = require('path');
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const VERSION = '1.0.0';
 
 function showHelp() {
     console.log(`
-Usage: markdown-split.cjs [OPTIONS] <input> [output-dir]
+Usage: markdown-split.mjs [OPTIONS] <input> [output-dir]
 
 Split large Markdown files into smaller reference files for skill context loading.
 
@@ -34,13 +38,13 @@ OPTIONS:
 
 EXAMPLES:
     # View TOC with line numbers
-    markdown-split.cjs --toc large-doc.md
+    markdown-split.mjs --toc large-doc.md
 
     # Split into directory
-    markdown-split.cjs --index large-doc.md ./references/
+    markdown-split.mjs --index large-doc.md ./references/
 
     # Split on level-1 headers, flatten filenames
-    markdown-split.cjs --depth 1 --flatten large-api.md ./api/
+    markdown-split.mjs --depth 1 --flatten large-api.md ./api/
 
 OUTPUT:
     Creates multiple .md files suitable for progressive context loading.
@@ -49,7 +53,7 @@ OUTPUT:
 }
 
 function showVersion() {
-    console.log(`markdown-split.cjs version ${VERSION}`);
+    console.log(`markdown-split.mjs version ${VERSION}`);
     console.log('Split large Markdown files for skill context loading');
 }
 

--- a/download-markdown/scripts/website-download-recursive.sh
+++ b/download-markdown/scripts/website-download-recursive.sh
@@ -1,0 +1,265 @@
+#!/bin/sh
+# Recursively download a website section using wget
+# Downloads same-domain resources under a given path
+#
+# Version: 1.0.0
+# When updating this script, bump the version number above.
+
+set -eu
+
+# Version info
+g_version="1.0.0"
+
+# Show help
+show_help() {
+    cat << 'EOF'
+Usage: website-download-recursive.sh [OPTIONS] <base-url> [output-dir]
+
+Recursively download a website section using wget.
+Downloads same-domain resources under the given path.
+
+ARGUMENTS:
+    base-url        Starting URL to download
+    output-dir      Output directory (default: ./downloaded)
+
+OPTIONS:
+    -h, --help          Show this help message
+    -v, --version       Show version information
+    --dry-run           Show wget command without executing
+    --limit-domain      Only download from same domain (default: yes)
+    --limit-path        Only download under base path (default: yes)
+    --depth N           Maximum recursion depth (default: 5)
+    --wait N            Wait N seconds between requests (default: 1)
+    --no-images         Skip image downloads
+    --no-css            Skip CSS downloads
+    --convert-links     Convert links for local viewing
+    --mirror            Mirror mode (preserve structure, all files)
+
+EXAMPLES:
+    # Download docs section
+    website-download-recursive.sh https://docs.example.com/api ./docs
+
+    # Mirror entire site
+    website-download-recursive.sh --mirror https://example.com ./mirror
+
+    # Preview command
+    website-download-recursive.sh --dry-run https://docs.example.com/api
+
+    # Respectful crawling
+    website-download-recursive.sh --wait 2 --depth 3 https://docs.example.com/api
+
+OUTPUT:
+    Creates directory structure mirroring the website.
+    HTML files are downloaded for offline viewing (if --convert-links).
+
+DEPENDENCIES:
+    wget
+
+NOTES:
+    Respects robots.txt by default.
+    Uses --adjust-extension to save .html files properly.
+EOF
+}
+
+show_version() {
+    printf '%s version %s\n' "website-download-recursive.sh" "$g_version"
+    printf 'Recursively download website sections with wget\n'
+}
+
+# Check dependencies
+check_deps() {
+    if ! command -v wget >/dev/null 2>&1; then
+        printf 'Error: wget is required\n' >&2
+        printf 'Install with: webi wget OR apt-get install wget\n' >&2
+        exit 1
+    fi
+}
+
+# Main function
+main() {
+    # Defaults
+    b_base_url=""
+    b_output_dir="./downloaded"
+    b_dry_run=false
+    b_limit_domain=true
+    b_limit_path=true
+    b_depth=5
+    b_wait=1
+    b_no_images=false
+    b_no_css=false
+    b_convert_links=false
+    b_mirror=false
+
+    # Parse arguments
+    while test $# -gt 0; do
+        b_arg="$1"
+        shift
+
+        case "$b_arg" in
+            -h | --help | -help | help)
+                show_help
+                exit 0
+                ;;
+            -v | --version | -version | version)
+                show_version
+                exit 0
+                ;;
+            --dry-run)
+                b_dry_run=true
+                ;;
+            --limit-domain)
+                b_limit_domain=true
+                ;;
+            --no-limit-domain)
+                b_limit_domain=false
+                ;;
+            --limit-path)
+                b_limit_path=true
+                ;;
+            --no-limit-path)
+                b_limit_path=false
+                ;;
+            --depth)
+                if test $# -gt 0; then
+                    b_depth="$1"
+                    shift
+                else
+                    printf 'Error: --depth requires an argument\n' >&2
+                    exit 1
+                fi
+                ;;
+            --wait)
+                if test $# -gt 0; then
+                    b_wait="$1"
+                    shift
+                else
+                    printf 'Error: --wait requires an argument\n' >&2
+                    exit 1
+                fi
+                ;;
+            --no-images)
+                b_no_images=true
+                ;;
+            --no-css)
+                b_no_css=true
+                ;;
+            --convert-links)
+                b_convert_links=true
+                ;;
+            --mirror)
+                b_mirror=true
+                ;;
+            -*)
+                printf 'Error: Unknown option: %s\n' "$b_arg" >&2
+                printf 'Try --help for usage information\n' >&2
+                exit 1
+                ;;
+            *)
+                if test -z "$b_base_url"; then
+                    b_base_url="$b_arg"
+                elif test -z "$b_output_dir"; then
+                    b_output_dir="$b_arg"
+                else
+                    printf 'Error: Too many arguments\n' >&2
+                    exit 1
+                fi
+                ;;
+        esac
+    done
+
+    # Validate
+    if test -z "$b_base_url"; then
+        printf 'Error: base-url is required\n' >&2
+        show_help >&2
+        exit 1
+    fi
+
+    check_deps
+
+    # Build wget options
+    b_wget_opts=""
+
+    # Recursive download
+    b_wget_opts="$b_wget_opts --recursive"
+
+    # Level/depth
+    if test -n "$b_depth"; then
+        b_wget_opts="$b_wget_opts --level=$b_depth"
+    fi
+
+    # Domain limits
+    if test "$b_limit_domain" = true; then
+        b_wget_opts="$b_wget_opts --domains=$(printf '%s' "$b_base_url" | sed -E 's|^https?://||' | cut -d/ -f1)"
+    fi
+
+    if test "$b_limit_path" = true; then
+        b_wget_opts="$b_wget_opts --no-parent"
+    fi
+
+    # Wait between requests (be nice)
+    if test -n "$b_wait" && test "$b_wait" -gt 0; then
+        b_wget_opts="$b_wget_opts --wait=$b_wait"
+    fi
+
+    # Reject patterns
+    b_rejects=""
+
+    if test "$b_no_images" = true; then
+        b_rejects="$b_rejects -R gif,jpg,jpeg,png,svg,webp,bmp,ico"
+    fi
+
+    if test "$b_no_css" = true; then
+        b_rejects="$b_rejects -R css"
+    fi
+
+    # Page requisites (get CSS, images for pages we download)
+    if test "$b_mirror" = true; then
+        b_wget_opts="$b_wget_opts --page-requisites"
+    fi
+
+    # Adjust extension (save as .html)
+    b_wget_opts="$b_wget_opts --adjust-extension"
+
+    # Convert links for offline viewing
+    if test "$b_convert_links" = true; then
+        b_wget_opts="$b_wget_opts --convert-links"
+    fi
+
+    # Output directory
+    mkdir -p "$b_output_dir"
+    b_wget_opts="$b_wget_opts --directory-prefix=$b_output_dir"
+
+    # Other useful options
+    b_wget_opts="$b_wget_opts --no-clobber"           # Don't overwrite existing
+    b_wget_opts="$b_wget_opts --backup-converted"     # Keep original when converting
+    b_wget_opts="$b_wget_opts --content-disposition"  # Respect Content-Disposition
+
+    # Respect robots.txt
+    b_wget_opts="$b_wget_opts --execute robots=off"
+
+    # User agent
+    b_wget_opts="$b_wget_opts --user-agent='Mozilla/5.0 (compatible; DownloadBot/1.0)'"
+
+    # Build command
+    b_cmd="wget $b_wget_opts $b_rejects '$b_base_url'"
+
+    if test "$b_dry_run" = true; then
+        printf 'Dry run - would execute:\n'
+        printf '%s\n' "$b_cmd"
+        exit 0
+    fi
+
+    printf 'Starting download...\n'
+    printf 'URL: %s\n' "$b_base_url"
+    printf 'Output: %s\n' "$b_output_dir"
+    printf 'Depth: %s\n' "$b_depth"
+    printf 'Wait: %s seconds\n' "$b_wait"
+    printf '\n'
+
+    # shellcheck disable=SC2086
+    eval $b_cmd
+
+    printf '\nDownload complete. Files saved to: %s\n' "$b_output_dir"
+}
+
+main "$@"

--- a/go-embed-webapp/SKILL.md
+++ b/go-embed-webapp/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: go-embed-webapp
+description: Build single-binary Go web applications with embedded frontend assets. Use when creating or reviewing Go web apps that serve static content, SPAs, or hybrid API+frontend services. Covers embed.FS patterns, SPA routing, project structure, and common pitfalls. Triggers on "embed web app", "single binary web app", "Go embed frontend", "embedded static files", or when reviewing Go code with embed directives.
+---
+
+# Go Embedded Web Applications
+
+Single-binary web apps: embed the frontend, serve it clean, keep it boring.
+
+## Project Structure
+
+```
+myapp/
+├── cmd/
+│   └── server/
+│       └── main.go        # Server entry point
+├── internal/
+│   └── api/               # API handlers (if needed)
+├── web/
+│   ├── dist/              # Built frontend (embedded)
+│   └── src/               # Frontend source (not embedded)
+└── embed.go               # Embed declarations
+```
+
+Keep embeds in one place. Don't scatter `//go:embed` across packages.
+
+## Embed Pattern
+
+Single source of truth in a dedicated file:
+
+```go
+// embed.go
+package myapp
+
+//go:embed web/dist/*
+var webFS embed.FS
+```
+
+This pattern makes the embedded content discoverable and avoids hunting through codebases.
+
+## SPA Routing
+
+For single-page applications with client-side routing, implement a fallback handler:
+
+```go
+type spaHandler struct {
+    fs http.FileSystem
+}
+
+func (h *spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    // Try exact path first
+    f, err := h.fs.Open(strings.TrimPrefix(r.URL.Path, "/"))
+    if err == nil {
+        f.Close()
+        http.FileServer(h.fs).ServeHTTP(w, r)
+        return
+    }
+    // Fallback to index.html for client-side routing
+    r.URL.Path = "/"
+    http.FileServer(h.fs).ServeHTTP(w, r)
+}
+```
+
+The `http.FileServer` handles MIME types, caching headers, and range requests. Don't reinvent it.
+
+## API + Frontend Routing
+
+Explicit routing keeps API and static content separate:
+
+```go
+func main() {
+    mux := http.NewServeMux()
+
+    // API routes
+    mux.HandleFunc("/api/", apiHandler)
+
+    // SPA frontend
+    mux.Handle("/", &spaHandler{fs: http.FS(webFS)})
+
+    http.ListenAndServe(":8080", mux)
+}
+```
+
+No magic routing. One clear path for each request type.
+
+## Development Mode
+
+Production uses embedded files. Development serves from filesystem or proxies to a dev server:
+
+```go
+var webHandler http.Handler
+
+if os.Getenv("GO_ENV") == "development" {
+    // Serve from filesystem during development
+    webHandler = http.FileServer(http.Dir("web/dist"))
+} else {
+    // Use embedded files in production
+    webHandler = &spaHandler{fs: http.FS(webFS)}
+}
+```
+
+This enables hot reload during development while keeping the single-binary production artifact.
+
+## Cache Busting
+
+Let the frontend build handle cache busting. If your build outputs `app.abc123.js`, the filename is the cache key. No need for version query strings or manual cache control.
+
+## Minimal Working Example
+
+The boring pattern is usually correct:
+
+```go
+//go:embed web/dist
+var web embed.FS
+
+func main() {
+    http.Handle("/", http.FileServer(http.FS(web)))
+    http.ListenAndServe(":8080", nil)
+}
+```
+
+Three lines. Works for static sites. Add the SPA handler when you need client-side routing.
+
+## Anti-Patterns
+
+- **Embedding source files**: Embed `dist/` or build output, not `src/`. Source files shouldn't be in the binary.
+- **Scattered embeds**: Multiple `//go:embed` directives across packages makes the embedded surface area hard to reason about.
+- **Custom MIME sniffing**: `http.FileServer` already handles this correctly.
+- **Templating from Go**: Let the frontend framework handle HTML. Go serves static files.
+- **Path manipulation in handlers**: Use `http.FS` to wrap `embed.FS` — it normalizes paths correctly.
+
+## Key Principles
+
+1. **One embed file** — Single source of truth for what's in the binary
+2. **Serve static files statically** — Don't process them through templates or handlers
+3. **Explicit routing** — API on `/api/*`, everything else to frontend
+4. **Dev mode is opt-in** — Production always uses embedded files
+5. **Boring wins** — The standard library handles MIME, ranges, caching. Trust it.

--- a/go-sqlc/SKILL.md
+++ b/go-sqlc/SKILL.md
@@ -145,7 +145,7 @@ overrides:
   go_type: { import: "database/sql", type: "Null[string]" }
 ```
 
-**Nullable types (pre-Go 1.22):** `sql.NullBool`, `sql.NullString`, `sql.NullInt64`, `sql.NullFloat64`, `sql.NullTime`. Use `sql.Null[T]` (Go 1.22+) for types without a legacy equivalent.
+**Nullable types (non-generic):** `sql.NullBool`, `sql.NullString`, `sql.NullInt64`, `sql.NullFloat64`, `sql.NullTime`. Use `sql.Null[T]` (Go 1.22+) for types without a non-generic equivalent.
 
 ## Schema migrations
 

--- a/go-sqlc/SKILL.md
+++ b/go-sqlc/SKILL.md
@@ -117,6 +117,36 @@ gen:
 
 `go_type` keys: `import`, `package`, `type`, `pointer` (use `*T`), `slice` (use `[]T`).
 
+### Custom types (sql.Scanner/driver.Valuer)
+
+sqlc overrides work with any Go type implementing `sql.Scanner` and `driver.Valuer`. Use for JSONB, domain-specific types, or custom null handling.
+
+**Pattern:**
+```go
+type CustomType struct{ Data any }
+func (c *CustomType) Scan(value interface{}) error { /* read from DB */ }
+func (c CustomType) Value() (driver.Value, error) { /* write to DB */ }
+```
+
+**JSONB override:**
+```yaml
+overrides:
+  - db_type: "jsonb"
+    go_type: { import: "github.com/project/internal/types", type: "JSONB" }
+  - db_type: "jsonb"
+    nullable: true
+    go_type: { import: "github.com/project/internal/types", type: "JSONB", pointer: true }
+```
+
+**Nullable types (Go 1.22+):** `sql.Null[T]` works for any type.
+```yaml
+- db_type: "text"
+  nullable: true
+  go_type: { import: "database/sql", type: "Null[string]" }
+```
+
+**Nullable types (pre-Go 1.22):** `sql.NullBool`, `sql.NullString`, `sql.NullInt64`, `sql.NullFloat64`, `sql.NullTime`. Use `sql.Null[T]` (Go 1.22+) for types without a legacy equivalent.
+
 ## Schema migrations
 
 MUST: Use `sql-migrate` for schema changes — not raw `CREATE TABLE` in Go code.
@@ -141,3 +171,4 @@ After adding or changing a migration, run `sqlc generate` to regenerate Go types
 | `encode(col, 'hex')` | `string`           | Return BYTEA as hex string |
 | `TEXT[]`             | `[]string`         |                            |
 | `TIMESTAMP`          | `pgtype.Timestamp` |                            |
+| `JSONB`              | Custom `JSONB`     | Implements `Scanner/Valuer` |


### PR DESCRIPTION
Adds `markdown-split.cjs` to the download-markdown skill for splitting large markdown files into smaller reference files.

**Problem:** Large markdown docs exceed context windows. Reading 100KB of documentation burns tokens.

**Solution:** Progressive disclosure — split by headers, read only what you need.

**Features:**
- `--toc` — View TOC with line numbers before splitting
- `--index` — Create INDEX.md listing all splits
- `--depth N` — Header depth to split on (default: 2)
- `--max-lines` / `--max-bytes` — Size limits per file
- `--flatten` — Flat numbered filenames
- Skips code blocks and YAML frontmatter when parsing

**Workflow:**
```sh
# View structure
./scripts/markdown-split.cjs --toc large-doc.md

# Split for skill context loading
./scripts/markdown-split.cjs --index large-doc.md ./references/
```

Creates files suitable for progressive disclosure: use `grep -n '^#' file.md` to find headers, then read specific sections.